### PR TITLE
enable no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@
 //! pub struct AssetCodeSeed(...);
 //! ```
 
+#![no_std]
+
 pub mod brand;
 
 pub mod cap {


### PR DESCRIPTION
`cargo-nono` complains about this crate not supporting `no_std`, so here's a quick fix.